### PR TITLE
Support projects that log something on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,11 @@ The available variables are:
 
 ## Troubleshooting
 
+Since the generator relies on running `mix` in your project to gather information
+like compile paths and checks whether it's an umbrella project, it might not work
+properly if there is some output in the `mix run` output, like logs.
+
+A workaround for this is increasing log level or turning logging off for the
+time of graph generation.
+
 If a graph can't be generated for your project or seems to be incorrect please create an issue describing the problem.

--- a/test/graf_test.exs
+++ b/test/graf_test.exs
@@ -375,6 +375,27 @@ defmodule GrafTest do
              ]
   end
 
+  test "json with relationships can be generated for an application that logs at startup" do
+    # given
+    project = "application_logging_at_startup"
+    project_compiled(project)
+    graph_generator_compiled()
+
+    # when
+    output = graph_generated(project, ["--builtin"])
+
+    # then
+    assert Jason.decode!(output) ==
+             [
+               %{
+                 "name" => "ApplicationLoggingAtStartup.Application",
+                 "imports" => ["Logger", "Supervisor"]
+               },
+               %{"name" => "Logger", "imports" => []},
+               %{"name" => "Supervisor", "imports" => []}
+             ]
+  end
+
   defp deps_fetched_for_project(project_name) do
     {_, 0} = System.cmd("mix", ["deps.get"], cd: project_dir(project_name))
   end

--- a/test/heb_generation_test.exs
+++ b/test/heb_generation_test.exs
@@ -285,6 +285,26 @@ defmodule HEBGenerationTest do
            """
   end
 
+  test "HEB graph is generated for the `application_logging_at_startup` project with " <>
+         "builtin modules" do
+    # given
+    project = "application_logging_at_startup"
+
+    # when
+    output = svg_generated(project, %{"BUILTIN" => "true"})
+
+    # then
+    assert output == """
+           <svg viewBox="-477,-477,954,954" xmlns="http://www.w3.org/2000/svg"><g font-family="sans-serif" font-size="10"><g transform="rotate(-30.000000000000007) translate(377,0)"><text dy="0.31em" x="6" text-anchor="start">Application<title>ApplicationLoggingAtStartup.Application
+                       2 outgoing
+                       0 incoming</title></text></g><g transform="rotate(90) translate(377,0)"><text dy="0.31em" x="-6" text-anchor="end" transform="rotate(180)">Logger<title>Logger
+                       0 outgoing
+                       1 incoming</title></text></g><g transform="rotate(210.00000000000006) translate(377,0)"><text dy="0.31em" x="-6" text-anchor="end" transform="rotate(180)">Supervisor<title>Supervisor
+                       0 outgoing
+                       1 incoming</title></text></g></g><g stroke="#ccc" fill="none"><path style="mix-blend-mode: multiply;" d="M326.49157722673334,-188.50000000000003L276.1574590709453,-154.72708333333335C225.82334091515725,-120.9541666666667,125.15510460358111,-53.40833333333334,70.73984173245891,40.84166666666666C16.32457886133669,135.09166666666667,8.162289430668368,256.04583333333335,4.081144715334208,316.5229166666667L4.7770319507798133e-14,377"></path><path style="mix-blend-mode: multiply;" d="M326.49157722673334,-188.50000000000003L272.07631435561115,-161.79583333333335C217.6610514844889,-135.0916666666667,108.83052574224445,-81.68333333333335,0,-81.68333333333335C-108.83052574224445,-81.68333333333335,-217.6610514844889,-135.0916666666667,-272.07631435561115,-161.79583333333335L-326.49157722673334,-188.50000000000003"></path></g></svg>
+           """
+  end
+
   defp svg_generated(projects, options \\ %{})
 
   defp svg_generated(projects, options) when is_list(projects) do

--- a/test/test_projects/application_logging_at_startup/.formatter.exs
+++ b/test/test_projects/application_logging_at_startup/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/test/test_projects/application_logging_at_startup/.gitignore
+++ b/test/test_projects/application_logging_at_startup/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+application_logging_at_startup-*.tar
+

--- a/test/test_projects/application_logging_at_startup/README.md
+++ b/test/test_projects/application_logging_at_startup/README.md
@@ -1,0 +1,21 @@
+# ApplicationLoggingAtStartup
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `application_logging_at_startup` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:application_logging_at_startup, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/application_logging_at_startup](https://hexdocs.pm/application_logging_at_startup).
+

--- a/test/test_projects/application_logging_at_startup/lib/application_logging_at_startup.ex
+++ b/test/test_projects/application_logging_at_startup/lib/application_logging_at_startup.ex
@@ -1,0 +1,18 @@
+defmodule ApplicationLoggingAtStartup do
+  @moduledoc """
+  Documentation for `ApplicationLoggingAtStartup`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> ApplicationLoggingAtStartup.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/test/test_projects/application_logging_at_startup/lib/application_logging_at_startup/application.ex
+++ b/test/test_projects/application_logging_at_startup/lib/application_logging_at_startup/application.ex
@@ -1,0 +1,17 @@
+defmodule ApplicationLoggingAtStartup.Application do
+  @moduledoc false
+
+  use Application
+  require Logger
+
+  def start(_type, _args) do
+    children = []
+
+    Logger.error("this is an example log")
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: ApplicationLoggingAtStartup.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/test/test_projects/application_logging_at_startup/mix.exs
+++ b/test/test_projects/application_logging_at_startup/mix.exs
@@ -1,0 +1,29 @@
+defmodule ApplicationLoggingAtStartup.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :application_logging_at_startup,
+      version: "0.1.0",
+      elixir: "~> 1.10",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {ApplicationLoggingAtStartup.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/test/test_projects/application_logging_at_startup/test/test_helper.exs
+++ b/test/test_projects/application_logging_at_startup/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
This should fix #1 

@joao-maria-bose would you mind checking if this works for you?
If you want to use docker, I pushed an image with the following tag `studzien/graf:support-projects-logging-at-startup`